### PR TITLE
Remove extraneous content repositories

### DIFF
--- a/content-repositories.json
+++ b/content-repositories.json
@@ -1,5 +1,3 @@
 [
-  { "kind": "github", "project": "deconst/deconst-docs" },
-  { "kind": "github", "project": "rackerlabs/docs-quickstart" },
-  { "kind": "github", "project": "rackerlabs/docs-cloud-databases" }
+  { "kind": "github", "project": "deconst/deconst-docs" }
 ]


### PR DESCRIPTION
I was using a few extra content repositories while I was developing the Strider plugins, but I don't need them any more.
